### PR TITLE
Fix open bracket color in `return (<div>`

### DIFF
--- a/JSX.sublime-syntax
+++ b/JSX.sublime-syntax
@@ -64,7 +64,7 @@ contexts:
       with_prototype:
         - include: literal-string-template
         - include: comments
-        - match: (return)?\s*\(?(?=<([a-zA-Z]+|\/))
+        - match: (return)?\s*(?=\(?)(?=<([a-zA-Z]+|\/))
           captures:
             0: keyword.control.flow.js
           scope: punctuation.section.embedded.begin.jsx


### PR DESCRIPTION
```js
  render() {
    return (<div>
      whatever
    </div>)
  }
```

# Before: 
![image](https://user-images.githubusercontent.com/18501150/81638498-af0a4300-9419-11ea-9f70-0e058a1249f9.png)

# After:
![image](https://user-images.githubusercontent.com/18501150/81638475-a1ed5400-9419-11ea-85c1-8ef401756e10.png)
