### PR TITLE
Fix highlight with closed block expression on attr

### DIFF
--- a/JSX.sublime-syntax
+++ b/JSX.sublime-syntax
@@ -82,3 +82,5 @@ contexts:
                 - match: (?=\})
                   pop: true
                 - include: 'scope:source.js'
+            - match: \}
+              pop: true

--- a/JSX.sublime-syntax
+++ b/JSX.sublime-syntax
@@ -79,6 +79,6 @@ contexts:
             - match: \{
               push:
                 - meta_scope: meta.embedded.block.jsx.js
-                - match: \}
+                - match: (?=\})
                   pop: true
                 - include: 'scope:source.js'


### PR DESCRIPTION
fix: #2

```js
  render() {
    return (
      <div shadowSize={object = {"lol"}; React.Component('test')} shadowSize={2} shadowSize={2}>
        whatever
      </diddd>
    );
  }
```

# Before
![image](https://user-images.githubusercontent.com/18501150/81641906-673be980-9422-11ea-9e10-894b660d8704.png)

# After
![image](https://user-images.githubusercontent.com/18501150/81641882-5b502780-9422-11ea-9100-cb50e3a15df5.png)

